### PR TITLE
redesign PR summary card

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/features/pull-request/components/pr-summary.tsx
+++ b/src/features/pull-request/components/pr-summary.tsx
@@ -1,5 +1,24 @@
 import { PullRequest } from "@/features/pull-request/types/pull-request";
 import { Repo } from "@/features/pull-request/types/repo";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+  AlertCircle,
+  GitPullRequest,
+  Minus,
+  Plus,
+  User,
+  Users,
+} from "lucide-react";
+
+const PLACEHOLDER_STATS = {
+  filesChanged: 8,
+  linesAdded: 240,
+  linesRemoved: 75,
+};
+
+const REVIEW_FOCUS_ITEMS = ["Large changes", "Missing tests", "Complex logic"];
 
 export default function PullRequestSummary({
   repo,
@@ -8,17 +27,149 @@ export default function PullRequestSummary({
   repo: Repo;
   pr: PullRequest | undefined;
 }) {
+  if (!pr) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <AlertCircle className="h-5 w-5 text-muted-foreground" />
+          <p className="text-[13px] font-medium text-foreground">
+            Pull request not found
+          </p>
+          <p className="text-[12px] text-muted-foreground">
+            Check the owner, repo name, and PR number and try again.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
-    <div className={`flex items-center justify-center gap-x-4 rounded-xl p-6 shadow-lg outline outline-white/5 ${pr ? "bg-slate-800" : "bg-red-500"}`}>
-      {pr ? (
-        <div>
-          <h3 className="font-semibold mb-4 text-xl">{`${repo.owner} / ${repo.name}`}</h3>
-          <p>{`${pr.title} #${pr.id}`}</p>
-          <p className="text-sm font-semibold">{`Requested by: ${pr.author}`}</p>
+    <Card className="animate-in fade-in slide-in-from-bottom-3 duration-500 ease-out">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <GitPullRequest className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-[13px] text-muted-foreground">
+              {repo.owner} / {repo.name}
+            </span>
+          </div>
+          <Badge
+            className={
+              pr.isOpen
+                ? "border-green-500/20 bg-green-500/10 text-green-400"
+                : "border-border bg-muted text-muted-foreground"
+            }
+          >
+            {pr.isOpen ? "Open" : "Closed"}
+          </Badge>
         </div>
-      ) : (
-        <h3 className="font-semibold">PR not found</h3>
-      )}
-    </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4 pt-0">
+        <div>
+          <h2 className="text-[15px] font-semibold leading-snug text-foreground">
+            {pr.title}
+            <span className="ml-1.5 font-mono text-[13px] font-normal text-foreground/50">
+              #{pr.id}
+            </span>
+          </h2>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Author
+            </span>
+            <div className="flex items-center gap-2">
+              <User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="text-[13px] text-foreground/80">{pr.author}</span>
+            </div>
+          </div>
+          {pr.reviewers && pr.reviewers.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Reviewers
+              </span>
+              <div className="flex items-center gap-2">
+                <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <div className="flex flex-wrap gap-1">
+                  {pr.reviewers.map((reviewer) => (
+                    <Badge
+                      key={reviewer}
+                      variant="secondary"
+                      className="text-[11px]"
+                    >
+                      {reviewer}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {pr.description && (
+          <p className="text-[13px] leading-5 text-muted-foreground">
+            {pr.description}
+          </p>
+        )}
+
+        <Separator />
+
+        <div className="flex flex-col gap-2">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Stats
+          </span>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="flex flex-col gap-0.5 rounded-lg bg-muted/50 px-3 py-2">
+              <span className="text-[11px] text-muted-foreground">
+                Files changed
+              </span>
+              <span className="text-[13px] font-medium text-foreground">
+                {PLACEHOLDER_STATS.filesChanged}
+              </span>
+            </div>
+            <div className="flex flex-col gap-0.5 rounded-lg bg-green-500/5 px-3 py-2">
+              <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                <Plus className="h-3 w-3" />
+                Added
+              </span>
+              <span className="text-[13px] font-medium text-green-400">
+                +{PLACEHOLDER_STATS.linesAdded}
+              </span>
+            </div>
+            <div className="flex flex-col gap-0.5 rounded-lg bg-red-500/5 px-3 py-2">
+              <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                <Minus className="h-3 w-3" />
+                Removed
+              </span>
+              <span className="text-[13px] font-medium text-red-400">
+                -{PLACEHOLDER_STATS.linesRemoved}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col gap-2">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Review focus
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {REVIEW_FOCUS_ITEMS.map((item) => (
+              <Badge
+                key={item}
+                className="border-amber-500/20 bg-amber-500/10 text-[11px] text-amber-400"
+              >
+                {item}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/pull-request/components/pr-viewer.tsx
+++ b/src/features/pull-request/components/pr-viewer.tsx
@@ -42,8 +42,8 @@ export default function PullRequestViewer() {
   };
 
   return (
-    <div className="flex min-h-[calc(100vh-4rem)] items-start justify-center bg-background px-4 pt-36">
-      <div className="animate-in fade-in slide-in-from-bottom-3 w-full max-w-[360px] space-y-3 duration-500 ease-out">
+    <div className="flex min-h-[calc(100vh-4rem)] items-start justify-center bg-background px-4 pt-12 sm:pt-36">
+      <div className="animate-in fade-in slide-in-from-bottom-3 w-full max-w-[360px] space-y-3 pb-12 duration-500 ease-out">
         <Card>
           <CardHeader className="pb-4">
             <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">


### PR DESCRIPTION
Closes #16

Redesigns the PR summary card in `pr-summary.tsx` using shadcn UI components (Card, Badge, Separator) with a structured layout.

Includes:

- Repository name, PR title, number, and author
- Reviewers and open/closed status
- PR description
- Placeholder stats and review focus items
- Not-found error state

> Stacked PR: depends on `feat/pr-review-form-ui`